### PR TITLE
Pinning InSpec version in audit wrapper.

### DIFF
--- a/cookbooks/dca_audit_baseline/attributes/default.rb
+++ b/cookbooks/dca_audit_baseline/attributes/default.rb
@@ -1,6 +1,9 @@
 default['audit']['fetcher'] = 'chef-server-automate'
 default['audit']['reporter'] = 'chef-server-automate'
 
+# Pin InSpec Version to known good
+default['audit']['inspec_version'] = '2.2.35'
+
 if node['os'] == 'linux'
   default['audit']['profiles'] = [
     {

--- a/cookbooks/dca_audit_baseline/metadata.rb
+++ b/cookbooks/dca_audit_baseline/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'nrycar@chef.io'
 license 'All Rights Reserved'
 description 'Baseline Security Audits'
 long_description 'Runs the dev-sec security baselines for linux or windows.'
-version '0.1.1'
+version '0.1.2'
 chef_version '>= 12.1' if respond_to?(:chef_version)
 
 depends 'audit'


### PR DESCRIPTION
Auth is borked in our workflow pipeline atm, and this doesn't require an environment build. Simple version pinning to fix known visualization issue.