### PR TITLE
get_workstation_ip.sh doesn't fall over when a stack isn't fully built yet

### DIFF
--- a/bin/get_workstation_ip.sh
+++ b/bin/get_workstation_ip.sh
@@ -8,4 +8,4 @@ else
   NAME="${USER}"
 fi
 
-aws cloudformation describe-stacks | jq -r '.[] | .[] | select(.StackName | contains("'"$NAME"'")) | ["\(.StackName)", "\(.Outputs | .[] | .OutputValue)"] | @tsv' | awk -v FS="\t" 'BEGIN {printf("%-69s %-25s\n" ,"\033[32mStackName\033[0m", "\033[32mWorkstationIP\033[0m")}{printf("%-60s %-16s\n", $1, $2)}'
+aws cloudformation describe-stacks | jq -r '.[] | .[] | select(.StackName | contains("'"$NAME"'")) | ["\(.StackName)", "\(.Outputs | .[]? | .OutputValue)"] | @tsv' | awk -v FS="\t" 'BEGIN {printf("%-69s %-25s\n" ,"\033[32mStackName\033[0m", "\033[32mWorkstationIP\033[0m")}{printf("%-60s %-16s\n", $1, $2==""?"(building)":$2)}'


### PR DESCRIPTION
Making time for the important stuff...

```
$ ./bin/get_workstation_ip.sh
StackName                                                    WorkstationIP
jvogt-Demo-practice-Chef-Demo-20180813T173732Z               (building)
```