### PR TITLE
Force json output

### DIFF
--- a/bin/get_workstation_ip.sh
+++ b/bin/get_workstation_ip.sh
@@ -8,4 +8,4 @@ else
   NAME="${USER}"
 fi
 
-aws cloudformation describe-stacks | jq -r '.[] | .[] | select(.StackName | contains("'"$NAME"'")) | ["\(.StackName)", "\(.Outputs | .[]? | .OutputValue)"] | @tsv' | awk -v FS="\t" 'BEGIN {printf("%-69s %-25s\n" ,"\033[32mStackName\033[0m", "\033[32mWorkstationIP\033[0m")}{printf("%-60s %-16s\n", $1, $2==""?"(building)":$2)}'
+aws cloudformation describe-stacks --output json | jq -r '.[] | .[] | select(.StackName | contains("'"$NAME"'")) | ["\(.StackName)", "\(.Outputs | .[]? | .OutputValue)"] | @tsv' | awk -v FS="\t" 'BEGIN {printf("%-69s %-25s\n" ,"\033[32mStackName\033[0m", "\033[32mWorkstationIP\033[0m")}{printf("%-60s %-16s\n", $1, $2==""?"(building)":$2)}'


### PR DESCRIPTION
on my system AWS was returning describe-stacks in get_workstation_ip as formatted string, not JSON. Added flag to force json output 